### PR TITLE
N予備の仕様変更に対応, manifest v3 に移行

### DIFF
--- a/cow.js
+++ b/cow.js
@@ -18,7 +18,7 @@ function next() {
   const cap = caps.find(
     (child) =>
       !child.textContent.includes("視聴済み") &&
-      child.querySelector("i").style.color === "rgb(179, 179, 179)"
+      child.querySelector('path').getAttribute('fill') === '#b3b3b3'
   );
 
   cap.childNodes?.[0].click();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "COW",
   "version": "0.0.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "N予備校自動再生ツール",
   "content_scripts": [{
     "matches": ["https://www.nnn.ed.nico/courses/*"],


### PR DESCRIPTION
### 概要
N予備校の仕様変更により、色を取得できなくなっていた。
色の取得方法を変更して再生されるようにした。
ついでに manifest v3 に対応させた。